### PR TITLE
Fix Ops cluster pod counts, RBAC, and scale control-plane replicas

### DIFF
--- a/api/handlers/ops_cluster.go
+++ b/api/handlers/ops_cluster.go
@@ -71,6 +71,54 @@ type pvcInfo struct {
 	StorageClass string `json:"storage_class"`
 }
 
+func shortNodeName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	if idx := strings.Index(name, "."); idx > 0 {
+		return name[:idx]
+	}
+	return name
+}
+
+func buildNodeNameLookup(nodes []clusterNode) map[string]string {
+	lookup := map[string]string{}
+	for _, n := range nodes {
+		raw := strings.TrimSpace(n.Name)
+		if raw == "" {
+			continue
+		}
+		short := shortNodeName(raw)
+		lookup[raw] = raw
+		lookup[strings.ToLower(raw)] = raw
+		lookup[short] = raw
+		lookup[strings.ToLower(short)] = raw
+	}
+	return lookup
+}
+
+func resolveNodeName(lookup map[string]string, name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	if canonical, ok := lookup[name]; ok {
+		return canonical
+	}
+	if canonical, ok := lookup[strings.ToLower(name)]; ok {
+		return canonical
+	}
+	short := shortNodeName(name)
+	if canonical, ok := lookup[short]; ok {
+		return canonical
+	}
+	if canonical, ok := lookup[strings.ToLower(short)]; ok {
+		return canonical
+	}
+	return name
+}
+
 // ---------- handler ----------
 
 func (h *OpsClusterHandler) Summary(w http.ResponseWriter, r *http.Request) {
@@ -167,11 +215,25 @@ func (h *OpsClusterHandler) Summary(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// ---------- pods (all namespaces) ----------
-	allPods, _ := kd.Client.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+	// ---------- pods ----------
+	podScope := "all_namespaces"
+	podWarnings := []string{}
+	allPods, allPodsErr := kd.Client.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+	if allPodsErr != nil {
+		podScope = ns
+		fallbackPods, fallbackErr := kd.Client.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
+		if fallbackErr != nil {
+			allPods = nil
+			podWarnings = append(podWarnings, "pod listing unavailable")
+		} else {
+			allPods = fallbackPods
+			podWarnings = append(podWarnings, "cluster-wide pod listing unavailable; showing namespace pod counts")
+		}
+	}
 	phases := podPhases{}
 	nsPodCounts := map[string]int{}
 	nodePodCounts := map[string]int{}
+	nodeNameLookup := buildNodeNameLookup(nodes)
 	totalPods := 0
 	if allPods != nil {
 		totalPods = len(allPods.Items)
@@ -189,8 +251,8 @@ func (h *OpsClusterHandler) Summary(w http.ResponseWriter, r *http.Request) {
 				phases.Unknown++
 			}
 			nsPodCounts[p.Namespace]++
-			if p.Spec.NodeName != "" {
-				nodePodCounts[p.Spec.NodeName]++
+			if nodeName := resolveNodeName(nodeNameLookup, p.Spec.NodeName); nodeName != "" {
+				nodePodCounts[nodeName]++
 			}
 		}
 	}
@@ -271,6 +333,7 @@ func (h *OpsClusterHandler) Summary(w http.ResponseWriter, r *http.Request) {
 	utils.RespondJSON(w, http.StatusOK, map[string]interface{}{
 		"enabled":   true,
 		"namespace": ns,
+		"pod_scope": podScope,
 		"cluster_totals": clusterTotals{
 			Nodes:             len(nodes),
 			Pods:              totalPods,
@@ -285,5 +348,6 @@ func (h *OpsClusterHandler) Summary(w http.ResponseWriter, r *http.Request) {
 		"pod_phases": phases,
 		"namespaces": namespaces,
 		"pvcs":       pvcs,
+		"warnings":   podWarnings,
 	})
 }

--- a/deploy/k8s/control-plane/control-plane.yaml
+++ b/deploy/k8s/control-plane/control-plane.yaml
@@ -17,7 +17,7 @@ metadata:
   name: railpush-control-plane
   namespace: railpush
 spec:
-  replicas: 2
+  replicas: 3
   selector:
     matchLabels:
       app: railpush-control-plane

--- a/deploy/k8s/control-plane/rbac.yaml
+++ b/deploy/k8s/control-plane/rbac.yaml
@@ -76,7 +76,8 @@ subjects:
     namespace: railpush
 ---
 # Cluster-scoped read-only access required for deriving per-node podCIDR base IPs
-# (flannel source IPs) used by hostNetwork ingress-nginx when proxying cross-node.
+# (flannel source IPs) used by hostNetwork ingress-nginx when proxying cross-node,
+# and for ops cluster summaries that aggregate pod counts by node.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -84,6 +85,9 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
     verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Summary
- fix `ops/cluster` pod counting by normalizing node names (short/FQDN) before aggregating per-node pod totals
- add fallback to namespace-scoped pod listing when cluster-wide listing is denied and return `pod_scope`/`warnings`
- grant cluster-scope `pods` read RBAC for control-plane cluster summaries
- scale `railpush-control-plane` deployment replicas from 2 to 3 for improved API-plane resilience